### PR TITLE
topページに遷移できない問題を解決

### DIFF
--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,0 +1,1 @@
+<h2>admin/top</h2>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,0 +1,1 @@
+<h2>pbulic/about</h2>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,0 +1,1 @@
+<h2>pbulic/top</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
   end
 
   #topページはapp/views/homes/topで設定
-  root to:"homes#top"
+  root to:"public/homes#top"
   #aboutページはapp/views/homes/aboutで設定
-  get 'about'=>'homes#about' ,as:'about'
+  get 'about'=>'public/homes#about' ,as:'about'
 end


### PR DESCRIPTION
ルーティングエラーは解決したので、プルリクしておきます。
原因
・ルーティングの記述が間違っていた
・Viewファイルがなかったため

※Webpack関係のエラーは出ます。