### PR TITLE
[Add]admin側の注文履歴機能を追加※ステータス更新は未実装

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -13,4 +13,9 @@ class Admin::CustomersController < ApplicationController
   def update
   end
 
+  private
+  def customers_params
+   # params.require(:〇〇テーブル名).permit(:〇〇, :〇〇カラム名)
+  end
+
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -19,4 +19,9 @@ class Admin::ItemsController < ApplicationController
   def update
   end
 
+  private
+  def customers_params
+   # params.require(:〇〇テーブル名).permit(:〇〇, :〇〇カラム名)
+  end
+
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,27 +1,41 @@
 class Admin::OrdersController < ApplicationController
-  #before_action :authenticate_admin!
+  before_action :authenticate_admin!
   #管理者以外には処理してほしくないので、最初にadminかどうかを確認
 
   def index
-   # @orders = Order.all
+   @orders = Order.all
+   @orders = Order.page(params[:page])
   end
 
   def show
-    # @order = Order.find(params[:id])
+   #@order = Order.find(params[:id])
+   @customer = order_customer
   end
 
   def update #注文ステータスの更新処理
   #@order = Order.find(params[:id])
-   # if @order.update(order_params)
-    #  redirect_to orders_path(@book.id), notice: "You have updated customer successfully."
+  #@order_detail = Order_detail.find(params[:id])
+    #if @order.update(order_params) && @order_detail.update(order_detail_params)
+     # redirect_to orders_path(@order.id)#, notice: "You have updated customer successfully."
     #else
-     # render :show#編集ページに戻る
+     # render :show#詳細ページに戻る
     #end
   end
 
+
+
   private
   def order_params
-   # params.require(:〇〇テーブル名).permit(:〇〇, :〇〇カラム名)
+   params.require(:order).permit(:customer_id,:name,:adress,:postal_code,:payment_method,:total_payment,:shipping_cost,:status)
+  end
+
+  def order_detail_params
+    params.require(:order_details).permit(:making_status)
+  end
+
+  def order_customer
+   @order = Order.find(params[:id])#その注文の情報を取得
+   @customer = @order.customer
   end
 
 end

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -4,6 +4,14 @@ class Admin::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def after_sign_in_path_for(resource)
+    admin_top_path
+  end
+
+  def after_sign_out_path_for(resource)
+    root_path
+  end
+
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -4,7 +4,7 @@ class Admin::SessionsController < Devise::SessionsController
   #before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    orders_path(resource)
+    admin_top_path
   end
 
   def after_sign_out_path_for(resource)

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,4 +3,8 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def full_name #苗字と名前をくっつけるメソッド
+    self.last_name + " " + self.first_name
+  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -6,4 +6,9 @@ class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
   has_many :cart_items, dependent: :destroy
   has_many :addresses,dependent: :destroy
+
+  def full_name #苗字と名前をくっつけるメソッド
+    self.last_name + " " + self.first_name
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,9 @@
 class Order < ApplicationRecord
-  belongs_to :customers
+  belongs_to :customer
   has_many :order_details, dependent: :destroy
+
+  def full_address #住所をくっつけるメソッド
+    self.postal_code + " " + self.address + " " + self.name
+  end
+
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,31 @@
+<div class="container px-5 px-sm-0">
+<!--= render 'layouts/errors', obj: @orders %--><!--エラー表示-->
+ <div class="row">
+  <div class="col">
+   <h2>注文履歴一覧</h2>
+   <table class="table table-hover table-inverse"><!--タイトルや本文など今まで登録したすべての情報を表示(収納)する枠-->
+    <thead>
+     <tr>
+      <th>購入日時</th>
+      <th>購入者</th>
+      <th>注文個数</th>
+      <th>注文ステータス</th><!--機能はまだ作成中-->
+     </tr>
+    </thead>
+    <tbody>
+     <% @orders.each do |f| %>
+      <tr>
+       <td>
+          <%= link_to f.created_at,admin_order_path(f) %>
+       </td>
+       <td><%= f.name %></td>
+       <!--td><!%= f.count %></td-->
+       <td>入金待ち</td>
+      </tr>
+     <% end %>
+    </tbody>
+   </table>
+   <%= paginate @orders %>
+  </div>
+ </div>
+</div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,0 +1,31 @@
+<div class="container px-5 px-sm-0">
+<!--%= render 'layouts/errors', obj: @order %--><!--エラー表示（今回は表示なし）-->
+ <div class="row">
+  <div class="col">
+   <h2>注文履歴詳細</h2>
+   <table class="table table-hover table-inverse"><!--タイトルや本文などを表示(収納)する枠-->
+    <thead>
+     <tr>
+      <th>購入者:<%= link_to @customer.full_name,admin_customer_path(@order) %></th><!--admin側の会員詳細ページへ遷移-->
+      <th>注文日：</th>
+      <th>配送先：<%= @order.full_address %></th>
+      <th>支払方法：<%= @order.payment_method%></th>
+      <th>注文ステータス：入金待ち（機能無し）</th>
+     </tr>
+    </thead>
+    <tbody>
+      <tr>
+       <tb>購入日時</tb>
+       <tb>購入者</tb>
+       <tb>注文個数</tb>
+       <tb colspan="2">注文ステータス</tb><!--機能はまだ作成中-->
+      </tr>
+      <tr>
+        <td></td>
+
+      </tr>
+    </tbody>
+   </table>
+  </div>
+ </div>
+</div>

--- a/app/views/admin/registrations/new.html.erb
+++ b/app/views/admin/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_with(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "admin/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,0 +1,14 @@
+<% if obj.errors.any? %>
+  <div id="error_explanation">
+
+    <!--以下エラーメッセージの日本語化用-->
+    <!--%= t("errors.template.header", model: User.model_name.human, count: obj.errors.count) %-->
+
+    <h3><%= pluralize(obj.errors.count, "error") %> prohibited this user from being saved:</h3>
+    <ul>
+      <% obj.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
       <%= render 'layouts/header' %>
     </header>
     </div>
+    <!--p id="notice"><!%= flash[:notice] %></p--><!--フラッシュメッセージ-->
     <%= yield %>
     <%= render 'layouts/footer' %>
   </body>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  # config.default_per_page = 25
+  config.default_per_page = 5
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
管理側の注文履歴一覧と詳細の表示完了（とりあえず表示のみ）
※ステータス更新は未実装です。

追加点
・ページネーション（config/initializers/kaminari）にて次のコメントアウト文を修正--->`config.default_per_page = 5`
・`full_name`と`full_address`の採用
　①モデルファイル(full_nameの場合、model/customer)にて次の構文を追加　※full_addressはorder
~~~
  def full_name #苗字と名前をくっつけるメソッド
    self.last_name + " " + self.first_name
  end
~~~
　②コントローラー(admin/order_controller)に次の記述を追加
~~~
def index
   @orders = Order.all #order
   @orders = Order.page(params[:page])
  end

  def show
   @customer = order_customer
  end

private
  def order_params #オーダーテーブルにある全てのカラム情報を取得するための下準備
   params.require(:order).permit(:customer_id,:name,:adress,:postal_code,:payment_method,:total_payment,:shipping_cost,:status)
  end

  def order_customer
   @order = Order.find(params[:id])#その注文の情報を取得
   @customer = @order.customer#取得したorderと紐づいたcustomerを取得
  end
~~~

