### PR TITLE
[fix]変数関係のエラーを修正（Admin）

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -3,8 +3,7 @@ class Admin::ItemsController < ApplicationController
   before_action :correct_item, only: [:show, :edit]
 
   def new
-
-    @item = Item.new
+    @item = Item.new #新規登録画面を映すための空の変数
   end
 
   def create
@@ -14,13 +13,11 @@ class Admin::ItemsController < ApplicationController
       redirect_to item_path(@item.id)
     else
       render :new
-  end
+    end
   end
 
   def index
-
-    @item = Item.page(params[:page])
-
+    @items = Item.page(params[:page])
   end
 
   def show


### PR DESCRIPTION
Admin側にて商品一覧が開けないエラーが発生していましたので、修正しました。
修正点は以下の通りです。

`controllers/admin/items`にて修正を行いました。
~~~
 def index
    @item = Item.page(params[:page])
 end
~~~
を
~~~
 def index
    @items = Item.page(params[:page])
 end
~~~
に修正

`@items`のｓが抜けてただけです！！